### PR TITLE
[DDO-2556] Make the publish job use 'the new way' to deploy to dev

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -76,14 +76,14 @@ jobs:
   #
   # Hey! You'll probably want to uncomment below this point: it deploys newly published versions to dev!
   #
-  # You'll need to create a new chart entry in Beehive first, at broad.io/beehive/charts/new (chart names
-  # can't be changed, so be sure beforehand). Replace 'javatemplate' below with whatever name you choose.
+  # You'll need to create a new chart entry in Beehive first, at https://broad.io/beehive/charts/new (chart 
+  # names can't be changed, so be sure beforehand). Replace 'javatemplate' below with whatever name you choose.
   #
   # You'll also need to add some access to your new repo to allow it to run these steps. We have docs on the
   # whole process here: https://docs.google.com/document/d/1lkUkN2KOpHKWufaqw_RIE7EN3vN4G2xMnYBU83gi8VA/edit#heading=h.ipfs1speial
   #
-  # Lastly, the deployment part won't work until your app has an actual chart and is deployed in dev. We
-  # can help with that, ping #dsp-devops-champions and we can point you in the right direction.
+  # Lastly, the deployment part won't work until your app has an actual chart and is deployed in dev. We can
+  # help with that, ping #dsp-devops-champions and we can point you in the right direction.
   #
 
   # report-to-sherlock:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,8 @@ jobs:
       contents: 'read'
       id-token: 'write'
     runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK
@@ -57,23 +59,53 @@ jobs:
       - name: Push GCR image
         run: docker push ${{ steps.image-name.outputs.name }}
 
-      - name: Deploy to Terra Dev environment
-        uses: broadinstitute/repository-dispatch@master
-        with:
-          token: ${{ secrets.BROADBOT_TOKEN }}
-          repository: broadinstitute/terra-helmfile
-          event-type: update-service
-          client-payload: '{"service": "javatemplate", "version": "${{ steps.tag.outputs.tag }}", "dev_only": false}'
+      # - name: Notify slack on failure
+      #   uses: broadinstitute/action-slack@v3.8.0
+      #   if: failure()
+      #   env:
+      #     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      #   with:
+      #     channel: '#jade-data-explorer'
+      #     status: failure
+      #     author_name: Publish to dev
+      #     fields: job
+      #     text: 'Publish failed :sadpanda:'
+      #     username: 'Terra Java Project Template GitHub Action'
 
-#      - name: Notify slack on failure
-#        uses: broadinstitute/action-slack@v3.8.0
-#        if: failure()
-#        env:
-#          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-#        with:
-#          channel: '#jade-data-explorer'
-#          status: failure
-#          author_name: Publish to dev
-#          fields: job
-#          text: 'Publish failed :sadpanda:'
-#          username: 'Terra Java Project Template GitHub Action'
+
+  #
+  # Hey! You'll probably want to uncomment below this point: it deploys newly published versions to dev!
+  #
+  # You'll need to create a new chart entry in Beehive first, at broad.io/beehive/charts/new (chart names
+  # can't be changed, so be sure beforehand). Replace 'javatemplate' below with whatever name you choose.
+  #
+  # You'll also need to add some access to your new repo to allow it to run these steps. We have docs on the
+  # whole process here: https://docs.google.com/document/d/1lkUkN2KOpHKWufaqw_RIE7EN3vN4G2xMnYBU83gi8VA/edit#heading=h.ipfs1speial
+  #
+  # Lastly, the deployment part won't work until your app has an actual chart and is deployed in dev. We
+  # can help with that, ping #dsp-devops-champions and we can point you in the right direction.
+  #
+
+  # report-to-sherlock:
+  #   # Report new version to Broad DevOps
+  #   uses: broadinstitute/sherlock/.github/workflows/client-report-app-version.yaml@main
+  #   needs: publish-job
+  #   with:
+  #     new-version: ${{ needs.publish-job.outputs.tag }}
+  #     chart-name: 'javatemplate'
+  #   permissions:
+  #     contents: 'read'
+  #     id-token: 'write'
+
+  # set-version-in-dev:
+  #   # Put new version in Broad dev environment
+  #   uses: broadinstitute/sherlock/.github/workflows/client-set-environment-app-version.yaml@main
+  #   needs: [publish-job, report-to-sherlock]
+  #   with:
+  #     new-version: ${{ needs.publish-job.outputs.tag }}
+  #     chart-name: 'javatemplate'
+  #     environment-name: 'dev'
+  #   secrets:
+  #     sync-git-token: ${{ secrets.BROADBOT_TOKEN }}
+  #   permissions:
+  #     id-token: 'write'

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ bin/
 
 # PyEnv environment files
 .env/
+
+# Ignore generated credentials from google-github-actions/auth
+gha-creds-*.json


### PR DESCRIPTION
'The new way' to deploy to dev is to contact Sherlock directly via reusable workflows. I wrote a [big doc](https://docs.google.com/document/d/1lkUkN2KOpHKWufaqw_RIE7EN3vN4G2xMnYBU83gi8VA/edit) on how to do this for existing repos, and I'll probably go through and do it for most of them myself, but I figure the template might as well include the happy path from the get-go.