### PR TITLE
[DDO-2875] No-op to trigger a re-publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -74,7 +74,7 @@ jobs:
 
 
   #
-  # Hey! You'll probably want to uncomment below this point: it deploys newly published versions to dev!
+  # Hey! You'll probably want to adjust below this point: it deploys newly published versions to dev!
   #
   # You'll need to create a new chart entry in Beehive first, at https://broad.io/beehive/charts/new (chart 
   # names can't be changed, so be sure beforehand). Replace 'javatemplate' below with whatever name you choose.


### PR DESCRIPTION
I need the latest build of the image to include https://github.com/broadinstitute/dsp-appsec-blessed-images/pull/40, so my hope is that merging a new PR will do just that. Just tweaking a comment to be a bit more accurate as some non-`.md` thing to edit.