### PR TITLE
Use new beehive slack reporting mechanism

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -194,24 +194,21 @@ jobs:
           path: |
             application.log
 
-  notify-slack:
-    needs: [ build, unit-tests-and-sonar, source-clear, integration-tests ]
-    runs-on: ubuntu-latest
+  # report workflow status in slack
+  # see https://docs.google.com/document/d/1G6-whnNJvON6Qq1b3VvRJFC7M9M-gu2dAVrQHDyp9Us/edit?usp=sharing
+  report-workflow:
+    uses: broadinstitute/sherlock/.github/workflows/client-report-workflow-status.yaml@main
+    with:
+      # Channels to notify upon workflow success or failure
+      notify-slack-channels-upon-workflow-completion: '#ap-k8s-monitor'
 
-    if: failure() && github.ref == 'refs/heads/main'
+      # Channels to notify upon workflow success only
+      # notify-slack-channels-upon-workflow-success: "#channel-here"
 
-    steps:
-      - name: Notify slack on failure
-        uses: broadinstitute/action-slack@v3.15.0
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        with:
-          channel: '#jade-data-explorer'
-          status: failure
-          author_name: Build on dev
-          fields: job,message
-          text: 'Build failed :sadpanda:'
-          username: 'Data Explorer GitHub Action'
+      # Channels to notify upon workflow failure only
+      # notify-slack-channels-upon-workflow-failure: "#channel-here"
+    permissions:
+      id-token: 'write'
 
   dispatch-tag:
     needs: [ build, unit-tests-and-sonar, source-clear, integration-tests ]

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -127,48 +127,18 @@ jobs:
           name: Test Reports
           path: integration/build/reports
 
-  notify-de-slack:
-    needs: [ build, jib, test-env, test-runner ]
-    runs-on: ubuntu-latest
-    if: failure()
+  # report workflow status in slack
+  # see https://docs.google.com/document/d/1G6-whnNJvON6Qq1b3VvRJFC7M9M-gu2dAVrQHDyp9Us/edit?usp=sharing
+  report-workflow:
+    uses: broadinstitute/sherlock/.github/workflows/client-report-workflow-status.yaml@main
+    with:
+      # Channels to notify upon workflow success or failure
+      notify-slack-channels-upon-workflow-completion: '#dsde-qa,#ap-k8s-monitor'
 
-    steps:
-      - name: "Notify #jade-data-explorer Slack on failure"
-        uses: broadinstitute/action-slack@v3.15.0
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          STATUS: failure
-        with:
-          channel: '#jade-data-explorer'
-          status: ${{ env.STATUS }}
-          fields: job,ref
-          text: >
-            ${{ format('Catalog test *{0}* in *{1}* {2}',
-            env.STATUS, needs.test-env.outputs.test-env,
-            env.STATUS == 'success' && ':check_green:' || ':sadpanda:') }}
-          username: 'Data Explorer Tests'
+      # Channels to notify upon workflow success only
+      # notify-slack-channels-upon-workflow-success: "#channel-here"
 
-  notify-qa-slack:
-    needs: [ build, jib, test-env, test-runner ]
-    runs-on: ubuntu-latest
-    if: always() && needs.test-env.outputs.test-env != 'dev'
-
-    steps:
-      - name: "Always notify #dsde-qa Slack"
-        uses: broadinstitute/action-slack@v3.15.0
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          STATUS: >-
-            ${{ needs.build.result == 'success'
-            && needs.jib.result == 'success'
-            && needs.test-runner.result == 'success'
-            && 'success' || 'failure' }}
-        with:
-          channel: '#dsde-qa'
-          status: ${{ env.STATUS }}
-          fields: job,ref
-          text: >
-            ${{ format('Catalog test *{0}* in *{1}* {2}',
-            env.STATUS, needs.test-env.outputs.test-env,
-            env.STATUS == 'success' && ':check_green:' || ':sadpanda:') }}
-          username: 'Data Explorer Tests'
+      # Channels to notify upon workflow failure only
+      # notify-slack-channels-upon-workflow-failure: "#channel-here"
+    permissions:
+      id-token: 'write'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,20 +59,6 @@ jobs:
       - name: Push GCR image
         run: docker push ${{ steps.image-name.outputs.name }}
 
-      # - name: Notify slack on failure
-      #   uses: broadinstitute/action-slack@v3.15.0
-      #   if: failure()
-      #   env:
-      #     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      #   with:
-      #     channel: '#jade-data-explorer'
-      #     status: failure
-      #     author_name: Publish to dev
-      #     fields: job
-      #     text: 'Publish failed :sadpanda:'
-      #     username: 'Terra Java Project Template GitHub Action'
-
-
   #
   # Hey! You'll probably want to adjust below this point: it deploys newly published versions to dev!
   #
@@ -107,5 +93,21 @@ jobs:
       environment-name: 'template-services'
     secrets:
       sync-git-token: ${{ secrets.BROADBOT_TOKEN }}
+    permissions:
+      id-token: 'write'
+
+  # report workflow status in slack
+  # see https://docs.google.com/document/d/1G6-whnNJvON6Qq1b3VvRJFC7M9M-gu2dAVrQHDyp9Us/edit?usp=sharing
+  report-workflow:
+    uses: broadinstitute/sherlock/.github/workflows/client-report-workflow-status.yaml@main
+    with:
+      # Channels to notify upon workflow success or failure
+      notify-slack-channels-upon-workflow-completion: '#workbench-resilience-dev'
+
+      # Channels to notify upon workflow success only
+      # notify-slack-channels-upon-workflow-success: "#channel-here"
+
+      # Channels to notify upon workflow failure only
+      # notify-slack-channels-upon-workflow-failure: "#channel-here"
     permissions:
       id-token: 'write'

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -33,19 +33,18 @@ jobs:
         with:
           image: ${{ steps.image-name.outputs.name }}
 
-  notify-slack:
-    needs: [ trivy ]
-    runs-on: ubuntu-latest
-    if: failure()
-    steps:
-      - name: Notify slack on failure
-        uses: broadinstitute/action-slack@v3.15.0
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        with:
-          channel: '#jade-data-explorer'
-          status: failure
-          author_name: Trivy action
-          fields: workflow,message
-          text: 'Trivy scan failure :sadpanda:'
-          username: 'Data Explorer GitHub Action'
+  # report workflow status in slack
+  # see https://docs.google.com/document/d/1G6-whnNJvON6Qq1b3VvRJFC7M9M-gu2dAVrQHDyp9Us/edit?usp=sharing
+  report-workflow:
+    uses: broadinstitute/sherlock/.github/workflows/client-report-workflow-status.yaml@main
+    with:
+      # Channels to notify upon workflow success or failure
+      notify-slack-channels-upon-workflow-completion: '#ap-k8s-monitor'
+
+      # Channels to notify upon workflow success only
+      # notify-slack-channels-upon-workflow-success: "#channel-here"
+
+      # Channels to notify upon workflow failure only
+      # notify-slack-channels-upon-workflow-failure: "#channel-here"
+    permissions:
+      id-token: 'write'


### PR DESCRIPTION
Update slack reporting from github workflows to use the new beehive based reporting mechanism instead of requiring each repo to setup their own slack webhook and corresponding secret.

[Doc with more info](https://docs.google.com/document/d/1G6-whnNJvON6Qq1b3VvRJFC7M9M-gu2dAVrQHDyp9Us/edit#heading=h.of3udlxcz8rt)