### PR TITLE
[WOR-1214] Increase max header size

### DIFF
--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -25,6 +25,7 @@ spring.config.import: optional:file:../config/local-properties.yml;classpath:git
 logging.pattern.level: '%X{requestId} %5p'
 
 server:
+  max-http-header-size: 32KB
   compression:
     enabled: true
     mimeTypes: text/css,application/javascript


### PR DESCRIPTION
Ticket: [WOR-1214](https://broadworkbench.atlassian.net/browse/WOR-1214)
* Incorporate fix for [WOR-1194](https://broadworkbench.atlassian.net/browse/WOR-1194) which we've been using in BPM and WSM to prevent encoded Google account profile pictures in the user's JWT from exceeding the max header size and causing 400s.

[WOR-1214]: https://broadworkbench.atlassian.net/browse/WOR-1214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WOR-1194]: https://broadworkbench.atlassian.net/browse/WOR-1194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ