### PR TITLE
Add Common Shell Scripting Library in support of Repo Standards Efforts

### DIFF
--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -1,12 +1,18 @@
 #!/usr/bin/env bash
 
+# To use these utilities you can source this file in your script
+# ie. source scripts/utils.sh
+
 # Basic logging lib
 
 # ERROR = 0
 # INFO = 1
 # DEBUG = 2
+
+
 declare -i desired_log_level=2
 
+# Usage: log_debug "your message"
 log_debug() { _log_execute 'DEBUG' "$1"; }
 log_info() { _log_execute 'INFO' "$1"; }
 log_err() { _log_execute 'ERROR' "$1"; }

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+# Basic logging lib
+
+# ERROR = 0
+# INFO = 1
+# DEBUG = 2
+declare -i desired_log_level=2
+
+log_debug() { _log_execute 'DEBUG' "$1"; }
+log_info() { _log_execute 'INFO' "$1"; }
+log_err() { _log_execute 'ERROR' "$1"; }
+
+_log_execute() {
+    local -r log_message=$2
+    local -r log_level=$1
+
+    case "$log_level" in
+        ERROR) priority=0;;
+        INFO)  priority=1;;
+        DEBUG) priority=2;;
+        *) return 1;;
+    esac
+
+    # check if level is at least desired level
+    [[ ${priority} -le ${desired_log_level} ]] && _log_msg "$log_message" "$log_level"
+
+    # don't want to exit with error code on messages of lower priority
+    return 0
+}
+
+_log_msg() {
+    local -r timestamp=$(date "+%Y-%m-%d %H:%M:%S")
+    echo "$timestamp [$2] $1"
+}
+
+# Helper function to check if required cli tools are installed
+# usage:
+# declare -r -a required_tools=( tool1 tool2 )
+# check_required_tools "${required_tools[@]}" || exit 1;
+check_required_tools() {
+  tools=( "$@" )
+  for tool in "${tools[@]}";
+  do
+    [[ $(type -P "$tool") ]] || {
+      log_err "$tool not found on PATH, please install $tool"
+      return 1;
+    }
+    log_debug "found $tool on PATH"
+  done
+  log_info 'all required tools found on PATH'
+}


### PR DESCRIPTION
After chatting with @cpate4 yesterday he suggested these might be useful to have in the template repo too.

This is in support of the Repo standards scripts being added in #23. This is my library of useful bash utilities that I like to use. Thought they might be helpful to folks here too.

This introduces a small bash utility library that provides a very basic set of functions for doing leveled logging output in scripts and a function that accepts an array of additional cli tools that need to be on the calling user's PATH to run a script and validates that they are all installed and accessible from PATH

Here is an example of both the log function out put and the `check_required_tools` function in action
![Screenshot 2024-03-07 at 8 07 30 AM](https://github.com/DataBiosphere/terra-java-project-template/assets/60187023/404bad20-875b-440c-a9a5-b23d528b9db6)

This could be expanded to include other common utilities as we discover a need for them too.
